### PR TITLE
Remove unnecessary params from API call.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,8 +167,6 @@ jobs:
             "namespace": "hotrod",
             "defaultService": "${defaultService}",
             "defaultServicePort": ${defaultPort},
-            "baseBranch": "${{ github.event.pull_request.base.ref }}",
-            "branch": "${{ github.event.pull_request.head.ref }}",
             "headCommit": "${{ github.event.pull_request.head.sha }}",
             "images": [ ${joined%,} ]
           }


### PR DESCRIPTION
The branch names are now fetched automatically on the backend.

The commit hash is also optional now, but it's a best practice to
include it when it's available because the images that CI has just built
might not correspond to the true head of the branch by the time it has
finished building them.