### PR TITLE
#978 hotrod: CI Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,74 +119,72 @@ jobs:
     needs: [ build, changes ]
     runs-on: ubuntu-latest
     outputs:
-      defaultService: ${{ steps.upsert_workspace.outputs.defaultService }}
-      previewURL: ${{ steps.upsert_workspace.outputs.previewURL }}
+      routePreviewURL: ${{ steps.upsert_workspace.outputs.routePreviewURL }}
     steps:
       - name: call signadot API
         id: upsert_workspace
         shell: bash
         run: |
           imageReplacements=()
-          defaultService=()
-          defaultPort=0
+          endpointSegments=('{"routeType": "static", "protocol": "http", "port": 8080, "host": "frontend.hotrod.svc"}')
 
           if [[ ${{ needs.changes.outputs.customer }} == 'true' ]]
           then
             imageReplacements+=('{"name": "signadot/hotrod-customer", "newTag": "${{ github.sha }}"}')
-            defaultService="customer"
-            defaultPort=8081
+            endpointSegments+=('{"routeType": "fork", "protocol": "http", "forkOf": {"kind": "Deployment", "name": "customer", "namespace": "hotrod"}}')
           fi
 
           if [[ ${{ needs.changes.outputs.driver }} == 'true' ]]
           then
             imageReplacements+=('{"name": "signadot/hotrod-driver", "newTag": "${{ github.sha }}"}')
-            defaultService="driver"
-            defaultPort=8082
+            endpointSegments+=('{"routeType": "fork", "protocol": "http", "forkOf": {"kind": "Deployment", "name": "driver", "namespace": "hotrod"}}')
           fi
 
           if [[ ${{ needs.changes.outputs.frontend }} == 'true' ]]
           then
             imageReplacements+=('{"name": "signadot/hotrod-frontend", "newTag": "${{ github.sha }}"}')
-            defaultService="frontend"
-            defaultPort=8080
+            endpointSegments+=('{"routeType": "fork", "protocol": "http", "forkOf": {"kind": "Deployment", "name": "frontend", "namespace": "hotrod"}}')
           fi
 
           if [[ ${{ needs.changes.outputs.route }} == 'true' ]]
           then
             imageReplacements+=('{"name": "signadot/hotrod-route", "newTag": "${{ github.sha }}"}')
-            defaultService="route"
-            defaultPort=8083
+            endpointSegments+=('{"routeType": "fork", "protocol": "http", "forkOf": {"kind": "Deployment", "name": "route", "namespace": "hotrod"}}')
           fi
 
           printf -v joined '%s,' "${imageReplacements[@]}"
-          echo ${joined%,}
+          printf -v endpoints '%s,' "${endpointSegments[@]}"
 
           payload=$(cat <<EOF
           {
             "cluster": "demo",
             "namespace": "hotrod",
-            "defaultService": "${defaultService}",
-            "defaultServicePort": ${defaultPort},
             "headCommit": "${{ github.event.pull_request.head.sha }}",
-            "images": [ ${joined%,} ]
+            "images": [ ${joined%,} ],
+            "endpoints": [ ${endpoints%,} ]
           }
           EOF
           )
+          echo "Request body:"
+          echo $payload | jq
           RESULT=$(curl -H 'Content-Type: application/json' \
                -H 'Authorization: ApiKey ${{ secrets.SIGNADOT_API_KEY }}' \
                -d "${payload}" \
           https://api.signadot.com/api/v1/repos/signadot/hotrod/pulls/${{ github.event.number }}/workspaces)
-          echo $RESULT
+          echo "Response body:"
+          echo $RESULT | jq
+
           ERROR=$(jq -r '.error' <<< $RESULT)
           if [ $ERROR != "null" ]; then
             echo "error: $ERROR"
             exit 1
           fi
-          PREVIEW_URL=$(jq -r '.previewURLs[0]' <<< $RESULT)
-               echo "::set-output name=defaultService::${defaultService}"
-               echo "::set-output name=previewURL::${PREVIEW_URL}"
+
+          routePreviewURL=$(jq -r '[.previewEndpoints[] | select(.forkOf != null and .forkOf.name == "route")] | .[0] | .previewURL' <<< $RESULT)
+          echo "Route preview URL: routePreviewURL"
+          echo "::set-output name=routePreviewURL::${routePreviewURL}"
   run_integration_tests:
-    if: ${{ github.event_name == 'pull_request' && needs.update_signadot.outputs.defaultService == 'route' }}
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.route == 'true' }}
     runs-on: ubuntu-latest
     needs: update_signadot
     steps:
@@ -213,8 +211,14 @@ jobs:
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-build-
       - name: Run Integration test on Route service
         run: |
-          previewURL=${{ needs.update_signadot.outputs.previewURL }}
-          echo $previewURL
+          routePreviewURL=${{ needs.update_signadot.outputs.routePreviewURL}}
+          echo "routePreviewURL: $routePreviewURL"
+
+          if [ $routePreviewURL == "null" ]; then
+            echo "error: could not find preview URL for route service"
+            exit 1
+          fi
+
           ./build.sh
           cd services/route
-          go test -v ./... --tags=integration -args -previewUrl=$previewURL -signadotApiKey=${{ secrets.SIGNADOT_API_KEY }}
+          go test -v ./... --tags=integration -args -previewUrl=$routePreviewURL -signadotApiKey=${{ secrets.SIGNADOT_API_KEY }}


### PR DESCRIPTION
### Changes
Replaced the deprecated defaultService and defaultServicePort in the upsert call with endpoints.
    - We'll now pass deployment fork endpoints for the services that have changed (eg. customer, driver, route, frontend). The reason we're going with deployment fork is because we show baseline preview endpoints on the UI only for the deployment forks. Also, the UX for service fork under additional preview endpoints section is yet to be streamlined.
    - Additionally, we'll be creating a new static endpoint for frontend irrespective of whether there were any changes to it or not. Made it static instead of fork (of service/deployment) because the latter won't work when there are no forked deployment/service (which aren only created when there is change to frontend).

### Screenshots

##### New call with endpoints
![image](https://user-images.githubusercontent.com/3791487/145308974-7d32f19b-07cc-400d-a39e-74464865300e.png)

Note:
The new integration test (using workspaces client) has only been setup in staging environment. Prod will continue to run the old integration test setup.

fixes [#978](https://github.com/signadot/signadot/issues/978)