### PR TITLE
k8s: Add Deployment manifests with Istio sidecar injection.

### DIFF
--- a/k8s/istio/customer.yaml
+++ b/k8s/istio/customer.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hotrod
+    component: customer
+  name: customer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hotrod
+      component: customer
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: hotrod
+        component: customer
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - args:
+            - customer
+          env:
+            - name: JAEGER_AGENT_HOST
+              value: jaeger
+            - name: JAEGER_AGENT_PORT
+              value: "6831"
+          image: signadot/hotrod-customer:latest
+          imagePullPolicy: Always
+          name: hotrod
+          ports:
+            - containerPort: 8081
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hotrod
+    component: customer
+  name: customer
+spec:
+  ports:
+    - name: http-web
+      port: 8081
+      targetPort: 8081
+  selector:
+    app: hotrod
+    component: customer

--- a/k8s/istio/driver.yaml
+++ b/k8s/istio/driver.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hotrod
+    component: driver
+  name: driver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hotrod
+      component: driver
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: hotrod
+        component: driver
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - args:
+            - driver
+          env:
+            - name: JAEGER_AGENT_HOST
+              value: jaeger
+            - name: JAEGER_AGENT_PORT
+              value: "6831"
+          image: signadot/hotrod-driver:latest
+          imagePullPolicy: Always
+          name: hotrod
+          ports:
+            - containerPort: 8082
+              name: web
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hotrod
+    component: driver
+  name: driver
+spec:
+  ports:
+    - name: grpc-web
+      port: 8082
+      targetPort: web
+  selector:
+    app: hotrod
+    component: driver

--- a/k8s/istio/frontend.yaml
+++ b/k8s/istio/frontend.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hotrod
+    component: frontend
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hotrod
+      component: frontend
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: hotrod
+        component: frontend
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - args:
+            - frontend
+          env:
+            - name: JAEGER_AGENT_HOST
+              value: jaeger
+            - name: JAEGER_AGENT_PORT
+              value: "6831"
+          image: signadot/hotrod-frontend:latest
+          imagePullPolicy: Always
+          name: hotrod
+          ports:
+            - containerPort: 8080
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hotrod
+    component: frontend
+  name: frontend
+spec:
+  ports:
+    - name: http-web
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: hotrod
+    component: frontend

--- a/k8s/istio/route.yaml
+++ b/k8s/istio/route.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hotrod
+    component: route
+  name: route
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hotrod
+      component: route
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: hotrod
+        component: route
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - args:
+            - route
+          env:
+            - name: JAEGER_AGENT_HOST
+              value: jaeger
+            - name: JAEGER_AGENT_PORT
+              value: "6831"
+          image: signadot/hotrod-route:latest
+          imagePullPolicy: Always
+          name: hotrod
+          ports:
+            - containerPort: 8083
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hotrod
+    component: route
+  name: route
+spec:
+  ports:
+    - name: http-web
+      port: 8083
+      targetPort: 8083
+  selector:
+    app: hotrod
+    component: route


### PR DESCRIPTION
This adds copies of the manifests from `pieces` with the Signadot sidecar annotation removed, and replaced with a label to enable Istio sidecar injection instead.

This will be used to test Signadot Operator in Istio mode.