### PR TITLE
Signadot example: update route service

### DIFF
--- a/services/route/server.go
+++ b/services/route/server.go
@@ -112,6 +112,6 @@ func computeRoute(ctx context.Context, pickup, dropoff string) *Route {
 	return &Route{
 		Pickup:  pickup,
 		Dropoff: dropoff,
-		ETA:     -time.Duration(eta) * time.Minute,
+		ETA:     time.Duration(eta) * time.Minute,
 	}
 }

--- a/services/route/server.go
+++ b/services/route/server.go
@@ -112,6 +112,6 @@ func computeRoute(ctx context.Context, pickup, dropoff string) *Route {
 	return &Route{
 		Pickup:  pickup,
 		Dropoff: dropoff,
-		ETA:     time.Duration(eta) * time.Hour,
+		ETA:     -time.Duration(eta) * time.Minute,
 	}
 }


### PR DESCRIPTION
This change aims to show a sample workflow using Signadot Sandboxes that runs integration tests on a real workload set up within a shared k8s cluster. The change makes use of integration tests written in Java using the [Signadot Java SDK](https://docs.signadot.com/docs/java-sdk) to bring up a temporary workspace, test the service using real dependencies and then tearing back down. The list of SDKs in which workspaces can be created and used is growing. Please refer to [this list](https://docs.signadot.com/docs/apis-and-sdks) for the latest.

1. The first commit makes a change that "fixes" a bug in the route service wherein it reports the time to route a cab back to the user in hours instead of minutes. However, it accidentally introduces a bug which causes the ETA to turn negative. The test that fails is this one:

https://github.com/signadot/hotrod/blob/aa2c572ee4e785cf69c23aa2b6ff98a29fffedc1/test/api-test/src/test/java/RouteServiceTest.java#L81-L90

2. The second commit fixes the bug introduced in the above fix and shows how the integration test runs successfully to completion. 