### PR TITLE
[DO NOT MERGE] Negative ETA for quickstart buggy start

### DIFF
--- a/services/route/server.go
+++ b/services/route/server.go
@@ -101,6 +101,6 @@ func (s *Server) FindRoute(ctx context.Context, req *FindRouteRequest) (*FindRou
 	}
 
 	return &FindRouteResponse{
-		EtaSeconds: int32(time.Duration(eta) / time.Second),
+		EtaSeconds: -1 * int32(time.Duration(eta)/time.Second),
 	}, nil
 }


### PR DESCRIPTION
This PR is not intended to be merged to master. It's just to tag and push docker image from to be used by quickstart. We already have an image created from such a change that's being used in quickstart. So this may in fact not be needed, but can be re-tagged/re-pushed in case there has been any newer changes that's needed for quickstart. After that, this can be closed.