### PR TITLE
makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,7 @@ release-images.txt:
 	done;
 
 tag-release:
-	(cd k8s/base && kustomize edit set image signadot/hotrod:$(RELEASE_TAG))
-	git diff-index --quiet HEAD || git commit -m tag-release-$(RELEASE_TAG) k8s/base
-	git tag -a -f -m release-$(RELEASE_TAG) $(RELEASE_TAG)
-	git push origin -f $(RELEASE_TAG)
+	./tag-release.sh $(RELEASE_TAG)
 
 release: build-release release-images.txt tag-release
 	for os in $(RELEASE_OSES); do \
@@ -69,3 +66,4 @@ generate-proto:
 	protoc --go_out=. --go_opt=paths=source_relative \
 		--go-grpc_out=. --go-grpc_opt=paths=source_relative \
 		services/route/route.proto
+

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+
+set -ex
+
+
+RELEASE_TAG=$1
+
+if [ -z ${RELEASE_TAG} ] ; then
+	echo "usage $0 <release-tag>"
+	exit 1
+fi
+
+if [ ! -d k8s/base ]; then
+	echo wrong dir
+	exit 1
+fi
+
+#
+# check for changes before editing images
+#
+set +e
+git diff  --exit-code
+if [ ! $? -eq 0 ]; then
+	echo "repository is dirty"
+	exit 1
+fi
+set -e
+
+(cd k8s/base && kustomize edit set image signadot/hotrod:${RELEASE_TAG})
+
+# do we need to commit the kustomize changes from above?
+set +e
+git diff  --exit-code
+diffCode=$?;
+
+set -e
+if [ ${diffCode} -eq 1 ] ; then 
+	git commit -m tag-release-${RELEASE_TAG} k8s/base
+	echo commited tag-release-${RELEASE_TAG}
+elif [ ${diffCode} -eq 0 ] ; then
+	echo image tag ${RELEASE_TAG} already committed
+else
+	echo "git diff-index failed"
+	exit 1
+fi
+
+
+# in any event, make sure we've tagged it locally and in-repo
+git tag -a -f -m release-${RELEASE_TAG} ${RELEASE_TAG}
+git push origin -f ${RELEASE_TAG}
+


### PR DESCRIPTION
The introduction of the use of `git diff-index --quiet HEAD` in the make target `tag-release` was incorrectly causing pushes of tags with the wrong image tag.  I think this was the root cause of https://github.com/signadot/signadot/issues/4587  (although the image tags present in kustomize sources at `e2e-v2.X` are fixed by https://github.com/signadot/signadot/issues/4585, this PR fixes the cause)

This PR makes `tag-release` idempotent, rather than reverting the call to `git diff-index`, as it seems was intended by the introduction of `git diff-index` .

One other gotcha I found was that `git diff-index --exit-code` can indicate there are differences when those differences (eg file modification times) don't necessarily cause `git commit` to commit changes, so `git diff --exit-code` is used in the replacement script here.


