### PR TITLE
Improvements to Location service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ main ]
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 
 ARG TARGETPLATFORM
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signadot/hotrod
 
-go 1.21.4
+go 1.22
 
 require (
 	github.com/IBM/sarama v1.42.1

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,6 @@ github.com/redis/go-redis/v9 v9.4.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/signadot/routesapi/go-routesapi v0.0.0-20240110192923-d8598a020267 h1:qP5ozxT0AMVxWrGZt7kyj8U7K/hl5tnIZuAW3vwpcVM=
-github.com/signadot/routesapi/go-routesapi v0.0.0-20240110192923-d8598a020267/go.mod h1:Noxoutt2PEwMSPbQdWnPQdQUBc2oPSNbtSuLg9jG0r4=
 github.com/signadot/routesapi/go-routesapi v0.0.0-20240202080216-ff62bea925c3 h1:Z9Hsn+dNBEq7kA7xqtHPXEil+yAvGoN0x1iYk69QpM4=
 github.com/signadot/routesapi/go-routesapi v0.0.0-20240202080216-ff62bea925c3/go.mod h1:Noxoutt2PEwMSPbQdWnPQdQUBc2oPSNbtSuLg9jG0r4=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=

--- a/services/location/interface.go
+++ b/services/location/interface.go
@@ -21,9 +21,9 @@ import (
 
 // Location contains data about a location.
 type Location struct {
-	ID          int64
-	Name        string
-	Coordinates string
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Coordinates string `json:"coordinates"`
 }
 
 // Interface exposed by the Location service.


### PR DESCRIPTION
This PR:
- Implements the create and delete locations endpoints.
- Makes the logic more resilient to the `Table 'location.locations' doesn't exist"` error (which happen whenever the `mysql` pod get recreated).
- Upgrades go from `1.21` to `1.22`.

FYI, I'm planning to tag this version as `e2e-v2.8` and use it in our e2e tests.
This allows running a signadot test like this (where the target vs the sandbox requests won't match but will be paired):

```python
def nonce(prefix):
	return prefix+random.randstr("abcdefghijklmnopqrstuvwxyz", 8)


def generateLocation():
    return {
        "name": nonce("Office "),
        "coordinates": str(random.randint(-90,90)) +","+ str(random.randint(-180,180))
    }


def createLocation(loc):
    res = http.post("http://location.hotrod-devmesh:8081/location", json_body=loc, capture=True, name="createLocation")
    return res.json()["id"]


def deleteLocation(id):
    params = {
        "locationID": str(id)
    }
    http.delete("http://location.hotrod-devmesh:8081/location", params=params, capture=True, name="deleteLocation")


def test():
    loc = generateLocation()
    print("The location="+ json.dumps(loc) +" was generated")

    locID = createLocation(loc)
    print("The locationID="+ str(locID) +" was created")

    deleteLocation(locID)
    print("The locationID="+ str(locID) +" was deleted")

test()
```