### PR TITLE
add a linkerd http route

### DIFF
--- a/k8s/overlays/prod/linkerd/http-route.yaml
+++ b/k8s/overlays/prod/linkerd/http-route.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy.linkerd.io/v1beta2
+kind: HTTPRoute
+metadata:
+  name: location-router
+spec:
+  parentRefs:
+    - name: location
+      kind: Service
+      group: core
+      port: 8081
+  rules:
+    - matches:
+      - headers:
+        - name: "x-refuse-connection"
+          value: "true"
+      backendRefs:
+        - name: "location"
+          port: 7981
+    - backendRefs:
+      - name: "location"
+        port: 8081

--- a/k8s/overlays/prod/linkerd/kustomization.yaml
+++ b/k8s/overlays/prod/linkerd/kustomization.yaml
@@ -1,9 +1,11 @@
 
 resources:
 - ../../../base
+- http-route.yaml
 
 patches:
 - path: frontend-linkerd-annotation.yaml
 - path: location-linkerd-annotation.yaml
 - path: driver-linkerd-annotation.yaml
 - path: route-linkerd-annotation.yaml
+- path: location-service.yaml

--- a/k8s/overlays/prod/linkerd/location-service.yaml
+++ b/k8s/overlays/prod/linkerd/location-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: location
+spec:
+  ports:
+      # this is a dummy port which is not listened to
+      # in order to actually exercise linkerd actively
+      # in our linkerd integration
+    - name: http-refuse-connection
+      port: 7981


### PR DESCRIPTION
this will help test that we do not interfere with linkerd

this is part of linkerd e2e-testing work in prep for operator v0.19.1

I hope to use this as e2e-v2.9

