### PR TITLE
[Route] Improve Driver ETAs - Arrive in Seconds

### DIFF
--- a/services/route/server.go
+++ b/services/route/server.go
@@ -76,7 +76,7 @@ func (s *Server) FindRoute(ctx context.Context, req *FindRouteRequest) (*FindRou
 	delay.Sleep(config.GetRouteCalcDelay(), config.GetRouteCalcStdDev())
 
 	// Generate a random number between 3 and 45 with decimals
-	eta := time.Duration((rand.Float64()*(45-3) + 3) * float64(time.Minute))
+	eta := time.Duration((rand.Float64()*(45-3) + 3) * float64(time.Second))
 	if os.Getenv("FAST_ROUTE") != "" {
 		eta = time.Second
 	}

--- a/services/route/server.go
+++ b/services/route/server.go
@@ -76,7 +76,7 @@ func (s *Server) FindRoute(ctx context.Context, req *FindRouteRequest) (*FindRou
 	delay.Sleep(config.GetRouteCalcDelay(), config.GetRouteCalcStdDev())
 
 	// Generate a random number between 3 and 45 with decimals
-	eta := time.Duration((rand.Float64()*(45-3) + 3) * float64(time.Second))
+	eta := time.Duration((rand.Float64()*(3-45) + 3) * float64(time.Second))
 	if os.Getenv("FAST_ROUTE") != "" {
 		eta = time.Second
 	}

--- a/services/route/server.go
+++ b/services/route/server.go
@@ -76,7 +76,7 @@ func (s *Server) FindRoute(ctx context.Context, req *FindRouteRequest) (*FindRou
 	delay.Sleep(config.GetRouteCalcDelay(), config.GetRouteCalcStdDev())
 
 	// Generate a random number between 3 and 45 with decimals
-	eta := time.Duration((rand.Float64()*(3-45) + 3) * float64(time.Second))
+	eta := time.Duration((rand.Float64()*(45-3) + 3) * float64(time.Second))
 	if os.Getenv("FAST_ROUTE") != "" {
 		eta = time.Second
 	}


### PR DESCRIPTION
This change modifies the Route Service ETA calculation so that drivers are dispatched in seconds rather than minutes.