### PR TITLE
Don't depend on routeserver being present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-frontend-app:
 	cd services/frontend/react_app && ./scripts/build.sh
 
 dev-build-docker: build
-	$(DOCKER) build -t signadot/hotrod:latest \
+	$(DOCKER) build -t signadot/hotrod:dev \
 		--platform $(GOOS)/$(GOARCH) \
 		.
 

--- a/services/driver/consumer.go
+++ b/services/driver/consumer.go
@@ -60,8 +60,6 @@ type Consumer struct {
 
 func newConsumer(ctx context.Context, tracerProvider trace.TracerProvider,
 	logger log.Factory) *Consumer {
-	// Log something funky during initialization
-	logger.Bg().Info("🚕 Vrooom! Driver service starting up! 🚗 Ready to find the fastest routes! 🛣️")
 
 	// Only initialize routing if routeserver URL is set and reachable
 	var routing watched.BaselineWatched


### PR DESCRIPTION
This works but it checks routeserver for reachability during initialization and I'd like to get it to be more dynamic. I am not sure if there's a more robust way here though - where we can just keep it more dynamic. I was hoping to find something like `baselineWatched.IsInitialized(...): bool`.