### PR TITLE
Add persisted ride history feature

### DIFF
--- a/services/frontend/react_app/src/pages/home.tsx
+++ b/services/frontend/react_app/src/pages/home.tsx
@@ -1,5 +1,6 @@
 import {MainLayout} from "../components/layouts";
 import {
+    Badge,
     Box,
     Button,
     Card,
@@ -7,6 +8,8 @@ import {
     CardHeader,
     Heading,
     HStack,
+    List,
+    ListItem,
     Stack,
     StackDivider,
     Text,
@@ -18,7 +21,7 @@ import styles from "./home.module.css";
 import {Logs} from "../components/features/logs/logs.tsx";
 import {Map} from "../components/features/map/map.tsx";
 import {useSession} from "../context/sessionContext/context.tsx";
-import {useEffect, useRef, useState} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 import {apiGet, apiPost} from "../services/http.ts";
 import {Locations} from "../types/location.ts";
 import {LocationSelect} from "../components/common/locationSelect/locationSelect.tsx";
@@ -26,6 +29,7 @@ import {useLogs} from "../hooks/useLogs.tsx";
 import {NotificationResponse} from "../types/notifications.ts";
 import {useGetRequestArrival} from "../hooks/useGetRequestArrival.tsx";
 import Countdown, {CountdownRenderProps} from "react-countdown";
+import {RideHistoryResponse} from "../types/rideHistory.ts";
 
 const countdownRenderer = ({minutes, seconds, driverName, driverPlate, props }: CountdownRenderProps & { driverName: string, driverPlate: string }) => {
     if (minutes === 0 && seconds === 0) {
@@ -39,6 +43,10 @@ export const HomePage = () => {
     const session = useSession();
     const notificationCursorRef = useRef(-1);
     const [locations, setLocations] = useState<Locations | undefined>();
+    const [rideHistory, setRideHistory] = useState<RideHistoryResponse>({
+        totalCount: 0,
+        entries: [],
+    });
 
     const [selectedLocations, setSelectedLocations] = useState({pickupId: -1, dropoffId: -1});
     const {logs, addNewLog, addErrorEntry, addInformationEntry} = useLogs();
@@ -47,6 +55,11 @@ export const HomePage = () => {
     const logsModal = useDisclosure();
     const toast = useToast();
 
+    const fetchRideHistory = useCallback(async () => {
+        const response = await apiGet<RideHistoryResponse>(`/ride-history?sessionID=${session.sessionID}`);
+        setRideHistory(response);
+    }, [session.sessionID]);
+
     useEffect(() => {
         const fetchLocations = async () => {
             const locations = await apiGet<Locations>('/splash');
@@ -54,7 +67,8 @@ export const HomePage = () => {
         }
 
         fetchLocations();
-    }, []);
+        fetchRideHistory();
+    }, [fetchRideHistory]);
 
     useEffect(() => {
         const pollNotifications = async () => {
@@ -73,6 +87,8 @@ export const HomePage = () => {
                     sandboxName: notification.context.sandboxName,
                 })
             });
+
+            await fetchRideHistory();
         }
 
         const intervalID = setInterval(pollNotifications, 2000);
@@ -81,7 +97,7 @@ export const HomePage = () => {
             clearInterval(intervalID);
         }
 
-    }, []);
+    }, [fetchRideHistory, session.sessionID]);
 
     if (!locations) {
         return (
@@ -127,6 +143,7 @@ export const HomePage = () => {
 
         try {
             await apiPost<{}>('/dispatch', data, {"baggage": `session=${sessionID}, request=${requestID}`});
+            await fetchRideHistory();
         } catch (e) {
             addErrorEntry(requestID, {
                 status: 'Error requesting a ride to frontend API',
@@ -205,6 +222,42 @@ export const HomePage = () => {
                                 overtime={lastRequestedDrive.driverArrival < 0}
                             />
                         </HStack>}
+                    <Card border={12} maxW={600}>
+                        <CardHeader>
+                            <HStack justifyContent='space-between' alignItems='center'>
+                                <Heading size='md' textAlign='left'>
+                                    Ride History
+                                </Heading>
+                                <Text fontWeight='bold'>Total rides: {rideHistory.totalCount}</Text>
+                            </HStack>
+                        </CardHeader>
+                        <CardBody>
+                            {rideHistory.entries.length === 0 && <Text>No rides requested yet.</Text>}
+                            {rideHistory.entries.length > 0 &&
+                                <List spacing={3}>
+                                    {rideHistory.entries.map(entry => (
+                                        <ListItem
+                                            key={`${entry.sessionID}-${entry.requestID}`}
+                                            borderWidth='1px'
+                                            borderRadius='md'
+                                            p={3}
+                                        >
+                                            <Stack spacing={1}>
+                                                <Text fontSize='sm' color='gray.600'>
+                                                    {new Date(entry.requestedAt).toLocaleString()}
+                                                </Text>
+                                                <Text><Text as='span' fontWeight='bold'>Pickup:</Text> {entry.pickupLocation}</Text>
+                                                <Text><Text as='span' fontWeight='bold'>Dropoff:</Text> {entry.dropoffLocation}</Text>
+                                                <HStack>
+                                                    <Text as='span' fontWeight='bold'>Driver plate:</Text>
+                                                    <Badge colorScheme='purple'>{entry.driverPlate || 'Pending assignment'}</Badge>
+                                                </HStack>
+                                            </Stack>
+                                        </ListItem>
+                                    ))}
+                                </List>}
+                        </CardBody>
+                    </Card>
                 </Stack>
                 <Stack flexGrow={1} justifyContent='space-between' w='50%' h='100%' maxH={'900px'}>
                     <div className={`${styles.drawer} ${logsModal.isOpen ? styles.open : ''}`}>

--- a/services/frontend/react_app/src/types/rideHistory.ts
+++ b/services/frontend/react_app/src/types/rideHistory.ts
@@ -1,0 +1,13 @@
+export type RideHistoryEntry = {
+    sessionID: number,
+    requestID: number,
+    pickupLocation: string,
+    dropoffLocation: string,
+    requestedAt: string,
+    driverPlate: string,
+}
+
+export type RideHistoryResponse = {
+    totalCount: number,
+    entries: RideHistoryEntry[],
+}

--- a/services/frontend/server.go
+++ b/services/frontend/server.go
@@ -16,6 +16,7 @@
 package frontend
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"expvar"
@@ -24,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -54,6 +56,13 @@ type Server struct {
 	location     location.Interface
 	notification notifications.Interface
 	dispatcher   *dispatcher
+}
+
+var driverPlateRegex = regexp.MustCompile(`Driver\s+(.*?)\s+arriving`)
+
+type rideHistoryResponse struct {
+	TotalCount int                         `json:"totalCount"`
+	Entries    []location.RideHistoryEntry `json:"entries"`
 }
 
 // NewServer creates a new frontend.Server
@@ -99,6 +108,7 @@ func (s *Server) createServeMux() http.Handler {
 	p := path.Join("/", s.basepath)
 	mux.Handle(path.Join(p, "/dispatch"), http.HandlerFunc(s.dispatch))
 	mux.Handle(path.Join(p, "/notifications"), http.HandlerFunc(s.notifications))
+	mux.Handle(path.Join(p, "/ride-history"), http.HandlerFunc(s.rideHistory))
 	mux.Handle(path.Join(p, "/debug/vars"), expvar.Handler())       // expvar
 	mux.Handle(path.Join(p, "/metrics"), promhttp.Handler())        // Prometheus
 	mux.Handle(path.Join(p, "/splash"), http.HandlerFunc(s.splash)) // Prometheus
@@ -190,6 +200,19 @@ func (s *Server) dispatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// persist a ride history entry for this request.
+	err = s.location.CreateRideHistory(ctx, &location.RideHistoryEntry{
+		SessionID:       dispatchReq.SessionID,
+		RequestID:       dispatchReq.RequestID,
+		PickupLocation:  pickupLoc.Name,
+		DropoffLocation: dropoffLoc.Name,
+		RequestedAt:     time.Now().UTC(),
+	})
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("couldn't persist ride history", zap.Error(err))
+		return
+	}
+
 	// dispatch a driver request
 	err = s.dispatcher.DispatchDriver(ctx, &dispatchReq, pickupLoc, dropoffLoc)
 	if httperr.HandleError(w, err, http.StatusInternalServerError) {
@@ -234,8 +257,63 @@ func (s *Server) notifications(w http.ResponseWriter, r *http.Request) {
 		s.logger.For(ctx).Error("request failed", zap.Error(err))
 		return
 	}
+	s.updateRideHistoryWithDriverNotifications(ctx, data)
 
 	s.writeResponse(data, w, r)
+}
+
+func (s *Server) rideHistory(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	s.logger.For(ctx).Info("HTTP request received", zap.String("method", r.Method), zap.Stringer("url", r.URL))
+	if err := r.ParseForm(); httperr.HandleError(w, err, http.StatusBadRequest) {
+		s.logger.For(ctx).Error("bad request", zap.Error(err))
+		return
+	}
+
+	sessionIDStr := r.Form.Get("sessionID")
+	if sessionIDStr == "" {
+		http.Error(w, "Missing required 'sessionID' parameter", http.StatusBadRequest)
+		return
+	}
+	sessionID, err := strconv.Atoi(sessionIDStr)
+	if err != nil || sessionID <= 0 {
+		http.Error(w, "Parameter 'sessionID' is not a positive integer", http.StatusBadRequest)
+		return
+	}
+
+	entries, err := s.location.ListRideHistory(ctx, uint(sessionID))
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("request failed", zap.Error(err))
+		return
+	}
+
+	s.writeResponse(rideHistoryResponse{
+		TotalCount: len(entries),
+		Entries:    entries,
+	}, w, r)
+}
+
+func (s *Server) updateRideHistoryWithDriverNotifications(ctx context.Context, data *notifications.NotificationList) {
+	for _, notification := range data.Notifications {
+		if notification.Context == nil || notification.Context.Request == nil {
+			continue
+		}
+
+		match := driverPlateRegex.FindStringSubmatch(notification.Body)
+		if len(match) < 2 {
+			continue
+		}
+		driverPlate := match[1]
+		reqCtx := notification.Context.Request
+		if err := s.location.UpdateRideHistoryDriver(ctx, reqCtx.SessionID, reqCtx.ID, driverPlate); err != nil {
+			s.logger.For(ctx).Error("couldn't update ride history driver plate",
+				zap.Error(err),
+				zap.Uint("session_id", reqCtx.SessionID),
+				zap.Uint("request_id", reqCtx.ID),
+				zap.String("driver_plate", driverPlate),
+			)
+		}
+	}
 }
 
 func (s *Server) writeResponse(response interface{}, w http.ResponseWriter, r *http.Request) {

--- a/services/location/client.go
+++ b/services/location/client.go
@@ -77,22 +77,67 @@ func (c *Client) Put(ctx context.Context, location *Location) error {
 	url := fmt.Sprintf("http://%s/location?locationID=%d", c.hostPort, location.ID)
 	fmt.Println(url)
 	var outLocation Location
-	if err := c.putJSON(ctx, url, location, outLocation); err != nil {
+	if err := c.putJSON(ctx, url, location, &outLocation); err != nil {
 		return err
 	}
 	return nil
 }
 
+func (c *Client) ListRideHistory(ctx context.Context, sessionID uint) ([]RideHistoryEntry, error) {
+	c.logger.For(ctx).Info("Getting ride history", zap.Uint("session_id", sessionID))
+
+	url := fmt.Sprintf("http://%s/ride-history?sessionID=%d", c.hostPort, sessionID)
+	var rides []RideHistoryEntry
+	if err := c.client.GetJSON(ctx, "/ride-history", url, &rides); err != nil {
+		return nil, err
+	}
+	return rides, nil
+}
+
+func (c *Client) CreateRideHistory(ctx context.Context, entry *RideHistoryEntry) error {
+	c.logger.For(ctx).Info("POST ride history",
+		zap.Uint("session_id", entry.SessionID),
+		zap.Uint("request_id", entry.RequestID))
+
+	url := fmt.Sprintf("http://%s/ride-history", c.hostPort)
+	var out RideHistoryEntry
+	return c.postJSON(ctx, url, entry, &out)
+}
+
+func (c *Client) UpdateRideHistoryDriver(ctx context.Context, sessionID, requestID uint, driverPlate string) error {
+	c.logger.For(ctx).Info("PUT ride history driver",
+		zap.Uint("session_id", sessionID),
+		zap.Uint("request_id", requestID),
+		zap.String("driver_plate", driverPlate))
+
+	url := fmt.Sprintf("http://%s/ride-history/driver", c.hostPort)
+	req := map[string]interface{}{
+		"sessionID":   sessionID,
+		"requestID":   requestID,
+		"driverPlate": driverPlate,
+	}
+	var out map[string]interface{}
+	return c.putJSON(ctx, url, req, &out)
+}
+
 func (c *Client) putJSON(ctx context.Context, url string, reqIn, respOut interface{}) error {
+	return c.sendJSON(ctx, http.MethodPut, url, reqIn, respOut)
+}
+
+func (c *Client) postJSON(ctx context.Context, url string, reqIn, respOut interface{}) error {
+	return c.sendJSON(ctx, http.MethodPost, url, reqIn, respOut)
+}
+
+func (c *Client) sendJSON(ctx context.Context, method, url string, reqIn, respOut interface{}) error {
 	d, err := json.Marshal(reqIn)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(d))
-	req.Header.Add("Content-type", "application/json")
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(d))
 	if err != nil {
 		return err
 	}
+	req.Header.Add("Content-type", "application/json")
 	req = req.WithContext(ctx)
 
 	res, err := c.client.Client.Do(req)
@@ -109,6 +154,10 @@ func (c *Client) putJSON(ctx context.Context, url string, reqIn, respOut interfa
 		}
 		return errors.New(string(body))
 	}
+	if respOut == nil {
+		return nil
+	}
+
 	decoder := json.NewDecoder(res.Body)
 	return decoder.Decode(respOut)
 }

--- a/services/location/database.go
+++ b/services/location/database.go
@@ -41,7 +41,7 @@ type database struct {
 	db     *sqlx.DB
 }
 
-const tableSchema = `
+const locationsTableSchema = `
 CREATE TABLE IF NOT EXISTS locations
 (
     id bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -50,6 +50,23 @@ CREATE TABLE IF NOT EXISTS locations
 
     PRIMARY KEY (id),
 	UNIQUE KEY name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+`
+
+const rideHistoryTableSchema = `
+CREATE TABLE IF NOT EXISTS ride_history
+(
+    id bigint unsigned NOT NULL AUTO_INCREMENT,
+    session_id bigint unsigned NOT NULL,
+    request_id bigint unsigned NOT NULL,
+    pickup_location varchar(255) NOT NULL,
+    dropoff_location varchar(255) NOT NULL,
+    requested_at datetime(6) NOT NULL,
+    driver_plate varchar(255) NOT NULL DEFAULT '',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_session_request (session_id, request_id),
+    KEY idx_requested_at (requested_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 `
 
@@ -258,6 +275,101 @@ func (d *database) Delete(ctx context.Context, locationID int) error {
 	return err
 }
 
+func (d *database) ListRideHistory(ctx context.Context, sessionID uint) ([]RideHistoryEntry, error) {
+	d.logger.For(ctx).Info("Loading ride history", zap.Uint("session_id", sessionID))
+
+	query := `SELECT session_id, request_id, pickup_location, dropoff_location, requested_at, driver_plate
+		FROM ride_history WHERE session_id = ? ORDER BY requested_at DESC`
+	rows, err := d.db.Query(query, sessionID)
+	if err != nil {
+		if !d.shouldRetry(err) {
+			return nil, err
+		}
+		rows, err = d.db.Query(query, sessionID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer rows.Close()
+
+	entries := make([]RideHistoryEntry, 0)
+	for rows.Next() {
+		entry := RideHistoryEntry{}
+		var sessionIDDB uint64
+		var requestIDDB uint64
+		if err := rows.Scan(
+			&sessionIDDB,
+			&requestIDDB,
+			&entry.PickupLocation,
+			&entry.DropoffLocation,
+			&entry.RequestedAt,
+			&entry.DriverPlate,
+		); err != nil {
+			return nil, err
+		}
+		entry.SessionID = uint(sessionIDDB)
+		entry.RequestID = uint(requestIDDB)
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (d *database) CreateRideHistory(ctx context.Context, entry *RideHistoryEntry) error {
+	d.logger.For(ctx).Info("Creating ride history entry",
+		zap.Uint("session_id", entry.SessionID),
+		zap.Uint("request_id", entry.RequestID))
+
+	query := `INSERT INTO ride_history
+		(session_id, request_id, pickup_location, dropoff_location, requested_at, driver_plate)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			pickup_location = VALUES(pickup_location),
+			dropoff_location = VALUES(dropoff_location),
+			requested_at = VALUES(requested_at)`
+	_, err := d.db.Exec(query,
+		entry.SessionID,
+		entry.RequestID,
+		entry.PickupLocation,
+		entry.DropoffLocation,
+		entry.RequestedAt,
+		entry.DriverPlate,
+	)
+	if err != nil {
+		if !d.shouldRetry(err) {
+			return err
+		}
+		_, err = d.db.Exec(query,
+			entry.SessionID,
+			entry.RequestID,
+			entry.PickupLocation,
+			entry.DropoffLocation,
+			entry.RequestedAt,
+			entry.DriverPlate,
+		)
+	}
+	return err
+}
+
+func (d *database) UpdateRideHistoryDriver(ctx context.Context, sessionID, requestID uint, driverPlate string) error {
+	d.logger.For(ctx).Info("Updating ride history driver",
+		zap.Uint("session_id", sessionID),
+		zap.Uint("request_id", requestID),
+		zap.String("driver_plate", driverPlate))
+
+	query := "UPDATE ride_history SET driver_plate = ? WHERE session_id = ? AND request_id = ?"
+	_, err := d.db.Exec(query, driverPlate, sessionID, requestID)
+	if err != nil {
+		if !d.shouldRetry(err) {
+			return err
+		}
+		_, err = d.db.Exec(query, driverPlate, sessionID, requestID)
+	}
+	return err
+}
+
 func (d *database) shouldRetry(err error) bool {
 	if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 		switch mysqlErr.Number {
@@ -271,15 +383,20 @@ func (d *database) shouldRetry(err error) bool {
 }
 
 func (d *database) setupDB() {
-	// Create the table
 	fmt.Println("creating locations table")
-	_, err := d.db.Exec(tableSchema)
+	_, err := d.db.Exec(locationsTableSchema)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("creating ride history table")
+	_, err = d.db.Exec(rideHistoryTableSchema)
 	if err != nil {
 		panic(err)
 	}
 
 	fmt.Println("seeding database")
-	stmt, err := d.db.Prepare("INSERT INTO locations (id, name, coordinates) VALUES (?, ?, ?)")
+	stmt, err := d.db.Prepare("INSERT IGNORE INTO locations (id, name, coordinates) VALUES (?, ?, ?)")
 	if err != nil {
 		panic(err)
 	}

--- a/services/location/interface.go
+++ b/services/location/interface.go
@@ -31,4 +31,7 @@ type Interface interface {
 	Get(ctx context.Context, locationID int) (*Location, error)
 	List(ctx context.Context) ([]Location, error)
 	Put(ctx context.Context, location *Location) error
+	ListRideHistory(ctx context.Context, sessionID uint) ([]RideHistoryEntry, error)
+	CreateRideHistory(ctx context.Context, entry *RideHistoryEntry) error
+	UpdateRideHistoryDriver(ctx context.Context, sessionID, requestID uint, driverPlate string) error
 }

--- a/services/location/ride_history.go
+++ b/services/location/ride_history.go
@@ -1,0 +1,13 @@
+package location
+
+import "time"
+
+// RideHistoryEntry represents one requested ride persisted in storage.
+type RideHistoryEntry struct {
+	SessionID       uint      `json:"sessionID"`
+	RequestID       uint      `json:"requestID"`
+	PickupLocation  string    `json:"pickupLocation"`
+	DropoffLocation string    `json:"dropoffLocation"`
+	RequestedAt     time.Time `json:"requestedAt"`
+	DriverPlate     string    `json:"driverPlate"`
+}

--- a/services/location/server.go
+++ b/services/location/server.go
@@ -76,6 +76,9 @@ func (s *Server) createServeMux() http.Handler {
 	mux.Handle("GET /location", http.HandlerFunc(s.getLocation))
 	mux.Handle("POST /location", http.HandlerFunc(s.createLocation))
 	mux.Handle("DELETE /location", http.HandlerFunc(s.deleteLocation))
+	mux.Handle("GET /ride-history", http.HandlerFunc(s.listRideHistory))
+	mux.Handle("POST /ride-history", http.HandlerFunc(s.createRideHistory))
+	mux.Handle("PUT /ride-history/driver", http.HandlerFunc(s.updateRideHistoryDriver))
 	mux.Handle("GET /healthz", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		s.logger.For(req.Context()).Info("/healthz")
 		resp.Write([]byte("ok"))
@@ -202,6 +205,99 @@ func (s *Server) deleteLocation(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("{}"))
 }
 
+func (s *Server) listRideHistory(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	s.logger.For(ctx).Info("HTTP request received", zap.String("method", r.Method), zap.Stringer("url", r.URL))
+	if err := r.ParseForm(); httperr.HandleError(w, err, http.StatusBadRequest) {
+		s.logger.For(ctx).Error("bad request", zap.Error(err))
+		return
+	}
+
+	sessionID, err := parseSessionID(r)
+	if httperr.HandleError(w, err, http.StatusBadRequest) {
+		s.logger.For(ctx).Error("bad request", zap.Error(err))
+		return
+	}
+
+	response, err := s.database.ListRideHistory(ctx, sessionID)
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("request failed", zap.Error(err))
+		return
+	}
+
+	data, err := json.Marshal(response)
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("cannot marshal response", zap.Error(err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+func (s *Server) createRideHistory(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	s.logger.For(ctx).Info("HTTP request received", zap.String("method", r.Method), zap.Stringer("url", r.URL))
+
+	var req RideHistoryEntry
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if httperr.HandleError(w, err, http.StatusBadRequest) {
+		s.logger.For(ctx).Error("bad request", zap.Error(err))
+		return
+	}
+
+	if req.RequestedAt.IsZero() {
+		req.RequestedAt = time.Now().UTC()
+	}
+
+	err = s.database.CreateRideHistory(ctx, &req)
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("request failed", zap.Error(err))
+		return
+	}
+
+	data, err := json.Marshal(req)
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("cannot marshal response", zap.Error(err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+type rideHistoryDriverUpdateRequest struct {
+	SessionID   uint   `json:"sessionID"`
+	RequestID   uint   `json:"requestID"`
+	DriverPlate string `json:"driverPlate"`
+}
+
+func (s *Server) updateRideHistoryDriver(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	s.logger.For(ctx).Info("HTTP request received", zap.String("method", r.Method), zap.Stringer("url", r.URL))
+
+	var req rideHistoryDriverUpdateRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if httperr.HandleError(w, err, http.StatusBadRequest) {
+		s.logger.For(ctx).Error("bad request", zap.Error(err))
+		return
+	}
+
+	if req.SessionID == 0 || req.RequestID == 0 || req.DriverPlate == "" {
+		http.Error(w, "sessionID, requestID and driverPlate are required", http.StatusBadRequest)
+		return
+	}
+
+	err = s.database.UpdateRideHistoryDriver(ctx, req.SessionID, req.RequestID, req.DriverPlate)
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("request failed", zap.Error(err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("{}"))
+}
+
 func parseLocationID(r *http.Request) (int, error) {
 	locationIDStr := r.Form.Get("locationID")
 	if locationIDStr == "" {
@@ -212,4 +308,19 @@ func parseLocationID(r *http.Request) (int, error) {
 		return 0, errors.New("parameter 'locationID' is not an integer")
 	}
 	return locationID, nil
+}
+
+func parseSessionID(r *http.Request) (uint, error) {
+	sessionIDStr := r.Form.Get("sessionID")
+	if sessionIDStr == "" {
+		return 0, errors.New("missing required 'sessionID' parameter")
+	}
+	sessionID, err := strconv.Atoi(sessionIDStr)
+	if err != nil {
+		return 0, errors.New("parameter 'sessionID' is not an integer")
+	}
+	if sessionID <= 0 {
+		return 0, errors.New("parameter 'sessionID' must be a positive integer")
+	}
+	return uint(sessionID), nil
 }

--- a/smart-tests/frontend/get-ride-history.star
+++ b/smart-tests/frontend/get-ride-history.star
@@ -1,0 +1,62 @@
+ck = smart_test.check("ride-history-status")
+
+payload = {
+    "sessionID": 998877,
+    "requestID": 445566,
+    "pickupLocationID": 1,
+    "dropoffLocationID": 731,
+}
+
+dispatch = http.post(
+    url="http://frontend.hotrod-devmesh.svc:8080/dispatch",
+    json_body=payload,
+    capture=True,
+    name="dispatchForRideHistory",
+)
+if dispatch.status_code != 200:
+    ck.error("dispatch request failed with status {}", dispatch.status_code)
+
+history = http.get(
+    url="http://frontend.hotrod-devmesh.svc:8080/ride-history?sessionID=998877",
+    capture=True,
+    name="getRideHistory",
+)
+
+if history.status_code != 200:
+    ck.error("ride history request failed with status {}", history.status_code)
+else:
+    body = history.json()
+    if type(body) != "dict":
+        ck.error("unexpected response type: {}", type(body))
+    else:
+        if not body.has("totalCount"):
+            ck.error("missing totalCount field in response")
+        if not body.has("entries"):
+            ck.error("missing entries field in response")
+
+        entries = body["entries"]
+        if type(entries) != "list":
+            ck.error("entries is not a list, got {}", type(entries))
+        elif len(entries) == 0:
+            ck.error("entries list is empty")
+        else:
+            expected_request_id = 445566
+            matching = None
+            for e in entries:
+                if type(e) != "dict":
+                    continue
+                if e.get("requestID") == expected_request_id:
+                    matching = e
+                    break
+
+            if matching == None:
+                ck.error("no ride history entry found for requestID {}", expected_request_id)
+            else:
+                if matching.get("pickupLocation") == "":
+                    ck.error("pickupLocation is empty")
+                if matching.get("dropoffLocation") == "":
+                    ck.error("dropoffLocation is empty")
+                if matching.get("requestedAt") == "":
+                    ck.error("requestedAt is empty")
+                if not matching.has("driverPlate"):
+                    ck.error("driverPlate field missing")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add persisted ride history storage in the location service (`ride_history` table) with APIs to create entries, list rides per session, and update driver plate per request
- update frontend backend handlers to store ride requests at dispatch time, expose a `/ride-history` response with total count + list, and backfill driver plate from driver dispatch notifications
- add home page UI to show ride history as a list view with pickup, dropoff, request time, driver plate, and total requested rides
- add a Signadot smart test for the new ride-history endpoint behavior in the `hotrod-devmesh` namespace path

## Validation
- focused Go tests for changed services pass
- local end-to-end run validates `/dispatch` persists ride history and `/ride-history` returns expected fields/count
- Signadot smart test run `fiiwfv46l4hs` (existing dispatch test) completed in sandbox `driver-plates`
- Signadot smart test run `fiixg1nmmznk` (new ride-history test) executed against `frontend.hotrod-devmesh.svc` and reports expected 404 check failures on baseline/target, confirming endpoint expectation gap in deployed environment

## Walkthrough artifacts
[ride_history_feature_demo.mp4](https://cursor.com/agents/bc-8627a9c7-94ec-4661-8133-70af854cf02b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_feature_demo.mp4)
[Ride history initial state](https://cursor.com/agents/bc-8627a9c7-94ec-4661-8133-70af854cf02b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_initial_state.webp)
[Ride history final state](https://cursor.com/agents/bc-8627a9c7-94ec-4661-8133-70af854cf02b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_final_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8627a9c7-94ec-4661-8133-70af854cf02b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8627a9c7-94ec-4661-8133-70af854cf02b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

