### PR TITLE
Add persistent Ride History list and count

### DIFF
--- a/services/driver/consumer.go
+++ b/services/driver/consumer.go
@@ -29,6 +29,7 @@ type Consumer struct {
 	routing      watched.BaselineWatched
 	driverStore  *driverStore
 	bestETA      *bestETA
+	rideHistory  *rideHistoryStore
 	notification notifications.Interface
 	ready        chan bool
 }
@@ -49,6 +50,7 @@ func newConsumer(ctx context.Context, tracerProvider trace.TracerProvider,
 		routing:      routing,
 		driverStore:  newDriverStore(tracer, logger),
 		bestETA:      newBestETA(tracerProvider, tracer, logger),
+		rideHistory:  newRideHistoryStore(),
 		notification: notifications.NewNotificationHandler(tracerProvider, logger),
 		ready:        make(chan bool),
 	}
@@ -166,4 +168,28 @@ func (consumer *Consumer) processDispatchRequest(msg *sarama.ConsumerMessage) {
 		Context:   notificationCtx,
 		Body:      fmt.Sprintf("Driver %s arriving in %s", bestDriver.DriverID, bestDriver.ETA.String()),
 	})
+
+	pickupLocation := "Unknown"
+	if dispatchReq.PickupLocation != nil {
+		pickupLocation = dispatchReq.PickupLocation.Name
+	}
+	dropoffLocation := "Unknown"
+	if dispatchReq.DropoffLocation != nil {
+		dropoffLocation = dispatchReq.DropoffLocation.Name
+	}
+	requestedAt := dispatchReq.RequestedAt
+	if requestedAt.IsZero() {
+		requestedAt = time.Now().UTC()
+	}
+
+	if err := consumer.rideHistory.Store(
+		ctx,
+		reqContext.ID,
+		pickupLocation,
+		dropoffLocation,
+		requestedAt,
+		bestDriver.DriverID,
+	); err != nil {
+		consumer.logger.For(ctx).Error("failed storing ride history", zap.Error(err))
+	}
 }

--- a/services/driver/interface.go
+++ b/services/driver/interface.go
@@ -1,5 +1,7 @@
 package driver
 
+import "time"
+
 import (
 	"github.com/signadot/hotrod/services/location"
 )
@@ -7,6 +9,8 @@ import (
 type DispatchRequest struct {
 	PickupLocation  *location.Location `json:"pickupLocation"`
 	DropoffLocation *location.Location `json:"dropoffLocation"`
+	RequestID       uint               `json:"requestID"`
+	RequestedAt     time.Time          `json:"requestedAt"`
 }
 
 type Driver struct {

--- a/services/driver/ride_history_store.go
+++ b/services/driver/ride_history_store.go
@@ -1,0 +1,103 @@
+package driver
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+type rideHistoryStore struct {
+	db *sqlx.DB
+}
+
+const rideHistoryTableSchema = `
+CREATE TABLE IF NOT EXISTS ride_history
+(
+	id bigint unsigned NOT NULL AUTO_INCREMENT,
+	request_id bigint unsigned NOT NULL,
+	pickup_location varchar(255) NOT NULL,
+	dropoff_location varchar(255) NOT NULL,
+	requested_at datetime(6) NOT NULL,
+	driver_plate varchar(255) NOT NULL,
+	PRIMARY KEY (id),
+	UNIQUE KEY request_id (request_id),
+	KEY requested_at (requested_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+`
+
+func newRideHistoryStore() *rideHistoryStore {
+	dsn := mysqlConfig().FormatDSN()
+	connectTicker := time.NewTicker(time.Second / 3)
+	defer connectTicker.Stop()
+
+	var (
+		db  *sqlx.DB
+		err error
+	)
+	for {
+		db, err = sqlx.ConnectContext(context.TODO(), "mysql", dsn)
+		if err == nil {
+			break
+		}
+		<-connectTicker.C
+	}
+
+	store := &rideHistoryStore{db: db}
+	store.setupTable()
+	return store
+}
+
+func mysqlConfig() *mysql.Config {
+	cfg := mysql.NewConfig()
+	cfg.Net = "tcp"
+	cfg.Addr = envOrDefault("MYSQL_ADDR", "mysql:3306")
+	cfg.DBName = envOrDefault("MYSQL_DBNAME", "location")
+	cfg.User = envOrDefault("MYSQL_USER", "root")
+	cfg.Passwd = os.Getenv("MYSQL_PASS")
+	cfg.Timeout = 60 * time.Second
+	cfg.InterpolateParams = true
+	cfg.ParseTime = true
+	cfg.Params = map[string]string{
+		"time_zone": "'+00:00'",
+	}
+	return cfg
+}
+
+func envOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func (s *rideHistoryStore) setupTable() {
+	ticker := time.NewTicker(time.Second / 3)
+	defer ticker.Stop()
+
+	for {
+		_, err := s.db.Exec(rideHistoryTableSchema)
+		if err == nil {
+			return
+		}
+		<-ticker.C
+	}
+}
+
+func (s *rideHistoryStore) Store(ctx context.Context, requestID uint,
+	pickupLocation, dropoffLocation string, requestedAt time.Time, driverPlate string) error {
+	query := `
+INSERT INTO ride_history (request_id, pickup_location, dropoff_location, requested_at, driver_plate)
+VALUES (?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	pickup_location = VALUES(pickup_location),
+	dropoff_location = VALUES(dropoff_location),
+	requested_at = VALUES(requested_at),
+	driver_plate = VALUES(driver_plate)
+`
+	_, err := s.db.ExecContext(ctx, query, requestID, pickupLocation, dropoffLocation, requestedAt, driverPlate)
+	return err
+}

--- a/services/frontend/dispatcher.go
+++ b/services/frontend/dispatcher.go
@@ -85,7 +85,7 @@ func (d *dispatcher) ResolveLocations(ctx context.Context,
 }
 
 func (d *dispatcher) DispatchDriver(ctx context.Context, req *DispatchRequest,
-	pickupLoc, dropoffLoc *location.Location) error {
+	pickupLoc, dropoffLoc *location.Location, requestedAt time.Time) error {
 	ctx, span := d.tracer.Start(ctx, "DispatchDriver", trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(
 		attribute.
@@ -97,6 +97,8 @@ func (d *dispatcher) DispatchDriver(ctx context.Context, req *DispatchRequest,
 	driverRequest := driver.DispatchRequest{
 		PickupLocation:  pickupLoc,
 		DropoffLocation: dropoffLoc,
+		RequestID:       req.RequestID,
+		RequestedAt:     requestedAt,
 	}
 	msgBody, err := json.Marshal(driverRequest)
 	if err != nil {

--- a/services/frontend/react_app/src/pages/home.tsx
+++ b/services/frontend/react_app/src/pages/home.tsx
@@ -26,6 +26,7 @@ import {useLogs} from "../hooks/useLogs.tsx";
 import {NotificationResponse} from "../types/notifications.ts";
 import {useGetRequestArrival} from "../hooks/useGetRequestArrival.tsx";
 import Countdown, {CountdownRenderProps} from "react-countdown";
+import {RideHistoryResponse} from "../types/rideHistory.ts";
 
 const countdownRenderer = ({minutes, seconds, driverName, driverPlate, props }: CountdownRenderProps & { driverName: string, driverPlate: string }) => {
     if (minutes === 0 && seconds === 0) {
@@ -39,6 +40,10 @@ export const HomePage = () => {
     const session = useSession();
     const notificationCursorRef = useRef(-1);
     const [locations, setLocations] = useState<Locations | undefined>();
+    const [rideHistory, setRideHistory] = useState<RideHistoryResponse>({
+        total: 0,
+        rides: [],
+    });
 
     const [selectedLocations, setSelectedLocations] = useState({pickupId: -1, dropoffId: -1});
     const {logs, addNewLog, addErrorEntry, addInformationEntry} = useLogs();
@@ -47,6 +52,11 @@ export const HomePage = () => {
     const logsModal = useDisclosure();
     const toast = useToast();
 
+    const fetchRideHistory = async () => {
+        const history = await apiGet<RideHistoryResponse>('/ride-history');
+        setRideHistory(history);
+    };
+
     useEffect(() => {
         const fetchLocations = async () => {
             const locations = await apiGet<Locations>('/splash');
@@ -54,6 +64,7 @@ export const HomePage = () => {
         }
 
         fetchLocations();
+        fetchRideHistory();
     }, []);
 
     useEffect(() => {
@@ -73,6 +84,7 @@ export const HomePage = () => {
                     sandboxName: notification.context.sandboxName,
                 })
             });
+            await fetchRideHistory();
         }
 
         const intervalID = setInterval(pollNotifications, 2000);
@@ -126,7 +138,7 @@ export const HomePage = () => {
         });
 
         try {
-            await apiPost<{}>('/dispatch', data, {"baggage": `session=${sessionID}, request=${requestID}`});
+            await apiPost<Record<string, never>>('/dispatch', data, {"baggage": `session=${sessionID}, request=${requestID}`});
         } catch (e) {
             addErrorEntry(requestID, {
                 status: 'Error requesting a ride to frontend API',
@@ -205,6 +217,33 @@ export const HomePage = () => {
                                 overtime={lastRequestedDrive.driverArrival < 0}
                             />
                         </HStack>}
+
+                    <Card border={12} maxW={600}>
+                        <CardHeader>
+                            <Heading size='md' textAlign='left'>Ride History</Heading>
+                            <Text mt={2} fontWeight='bold'>Total rides requested: {rideHistory.total}</Text>
+                        </CardHeader>
+                        <CardBody>
+                            <Stack as='ul' spacing={3} maxH='360px' overflowY='auto'>
+                                {rideHistory.rides.length === 0 && (
+                                    <Text>No rides requested yet.</Text>
+                                )}
+                                {rideHistory.rides.map((ride) => (
+                                    <Box
+                                        as='li'
+                                        key={`${ride.requestID}-${ride.requestedAt}`}
+                                        borderWidth='1px'
+                                        borderRadius='md'
+                                        p={3}
+                                    >
+                                        <Text><b>{ride.pickupLocation}</b> to <b>{ride.dropoffLocation}</b></Text>
+                                        <Text fontSize='sm'>Requested: {new Date(ride.requestedAt).toLocaleString()}</Text>
+                                        <Text fontSize='sm'>Driver plate: {ride.driverPlate}</Text>
+                                    </Box>
+                                ))}
+                            </Stack>
+                        </CardBody>
+                    </Card>
                 </Stack>
                 <Stack flexGrow={1} justifyContent='space-between' w='50%' h='100%' maxH={'900px'}>
                     <div className={`${styles.drawer} ${logsModal.isOpen ? styles.open : ''}`}>

--- a/services/frontend/react_app/src/types/rideHistory.ts
+++ b/services/frontend/react_app/src/types/rideHistory.ts
@@ -1,0 +1,12 @@
+export type RideHistoryEntry = {
+    requestID: number,
+    pickupLocation: string,
+    dropoffLocation: string,
+    requestedAt: string,
+    driverPlate: string,
+}
+
+export type RideHistoryResponse = {
+    total: number,
+    rides: RideHistoryEntry[],
+}

--- a/services/frontend/ride_history_store.go
+++ b/services/frontend/ride_history_store.go
@@ -1,0 +1,134 @@
+package frontend
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+type RideHistoryEntry struct {
+	RequestID       uint      `db:"request_id" json:"requestID"`
+	PickupLocation  string    `db:"pickup_location" json:"pickupLocation"`
+	DropoffLocation string    `db:"dropoff_location" json:"dropoffLocation"`
+	RequestedAt     time.Time `db:"requested_at" json:"requestedAt"`
+	DriverPlate     string    `db:"driver_plate" json:"driverPlate"`
+}
+
+type RideHistoryResponse struct {
+	Total int                `json:"total"`
+	Rides []RideHistoryEntry `json:"rides"`
+}
+
+type rideHistoryStore struct {
+	db *sqlx.DB
+}
+
+const rideHistoryTableSchema = `
+CREATE TABLE IF NOT EXISTS ride_history
+(
+	id bigint unsigned NOT NULL AUTO_INCREMENT,
+	request_id bigint unsigned NOT NULL,
+	pickup_location varchar(255) NOT NULL,
+	dropoff_location varchar(255) NOT NULL,
+	requested_at datetime(6) NOT NULL,
+	driver_plate varchar(255) NOT NULL,
+	PRIMARY KEY (id),
+	UNIQUE KEY request_id (request_id),
+	KEY requested_at (requested_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+`
+
+func newRideHistoryStore() *rideHistoryStore {
+	dsn := mysqlConfig().FormatDSN()
+	connectTicker := time.NewTicker(time.Second / 3)
+	defer connectTicker.Stop()
+
+	var (
+		db  *sqlx.DB
+		err error
+	)
+	for {
+		db, err = sqlx.ConnectContext(context.TODO(), "mysql", dsn)
+		if err == nil {
+			break
+		}
+		<-connectTicker.C
+	}
+
+	store := &rideHistoryStore{db: db}
+	store.setupTable()
+	return store
+}
+
+func mysqlConfig() *mysql.Config {
+	cfg := mysql.NewConfig()
+	cfg.Net = "tcp"
+	cfg.Addr = envOrDefault("MYSQL_ADDR", "mysql:3306")
+	cfg.DBName = envOrDefault("MYSQL_DBNAME", "location")
+	cfg.User = envOrDefault("MYSQL_USER", "root")
+	cfg.Passwd = os.Getenv("MYSQL_PASS")
+	cfg.Timeout = 60 * time.Second
+	cfg.InterpolateParams = true
+	cfg.ParseTime = true
+	cfg.Params = map[string]string{
+		"time_zone": "'+00:00'",
+	}
+	return cfg
+}
+
+func envOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func (s *rideHistoryStore) setupTable() {
+	ticker := time.NewTicker(time.Second / 3)
+	defer ticker.Stop()
+
+	for {
+		_, err := s.db.Exec(rideHistoryTableSchema)
+		if err == nil {
+			return
+		}
+		<-ticker.C
+	}
+}
+
+func (s *rideHistoryStore) Store(ctx context.Context, ride *RideHistoryEntry) error {
+	query := `
+INSERT INTO ride_history (request_id, pickup_location, dropoff_location, requested_at, driver_plate)
+VALUES (?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	pickup_location = VALUES(pickup_location),
+	dropoff_location = VALUES(dropoff_location),
+	requested_at = VALUES(requested_at),
+	driver_plate = VALUES(driver_plate)
+`
+	_, err := s.db.ExecContext(ctx, query, ride.RequestID, ride.PickupLocation, ride.DropoffLocation, ride.RequestedAt, ride.DriverPlate)
+	return err
+}
+
+func (s *rideHistoryStore) List(ctx context.Context) ([]RideHistoryEntry, error) {
+	query := `
+SELECT request_id, pickup_location, dropoff_location, requested_at, driver_plate
+FROM ride_history
+ORDER BY requested_at DESC, request_id DESC
+`
+	rides := make([]RideHistoryEntry, 0)
+	if err := s.db.SelectContext(ctx, &rides, query); err != nil {
+		return nil, err
+	}
+	return rides, nil
+}
+
+func (s *rideHistoryStore) UpdateDriverPlate(ctx context.Context, requestID uint, driverPlate string) error {
+	query := "UPDATE ride_history SET driver_plate = ? WHERE request_id = ?"
+	_, err := s.db.ExecContext(ctx, query, driverPlate, requestID)
+	return err
+}

--- a/services/frontend/server.go
+++ b/services/frontend/server.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -44,6 +45,9 @@ import (
 //go:embed web_assets/*
 var assetFS embed.FS
 
+var dispatchedDriverIDRegex = regexp.MustCompile(`^req-(\d+)-dispatched-driver$`)
+var dispatchedDriverBodyRegex = regexp.MustCompile(`^Driver\s+(.+?)\s+arriving in`)
+
 // Server implements hotrod-frontend service
 type Server struct {
 	addr     string
@@ -54,6 +58,7 @@ type Server struct {
 	location     location.Interface
 	notification notifications.Interface
 	dispatcher   *dispatcher
+	rideHistory  *rideHistoryStore
 }
 
 // NewServer creates a new frontend.Server
@@ -69,6 +74,7 @@ func NewServer(logger log.Factory) *Server {
 
 	// get a dispatcher
 	dispatcher := newDispatcher(tracerProvider, logger, locationClient)
+	rideHistory := newRideHistoryStore()
 
 	return &Server{
 		addr:     net.JoinHostPort("0.0.0.0", config.GetFrontendBindPort()),
@@ -79,6 +85,7 @@ func NewServer(logger log.Factory) *Server {
 		location:     locationClient,
 		notification: notificationHandler,
 		dispatcher:   dispatcher,
+		rideHistory:  rideHistory,
 	}
 }
 
@@ -99,6 +106,7 @@ func (s *Server) createServeMux() http.Handler {
 	p := path.Join("/", s.basepath)
 	mux.Handle(path.Join(p, "/dispatch"), http.HandlerFunc(s.dispatch))
 	mux.Handle(path.Join(p, "/notifications"), http.HandlerFunc(s.notifications))
+	mux.Handle(path.Join(p, "/ride-history"), http.HandlerFunc(s.rideHistoryList))
 	mux.Handle(path.Join(p, "/debug/vars"), expvar.Handler())       // expvar
 	mux.Handle(path.Join(p, "/metrics"), promhttp.Handler())        // Prometheus
 	mux.Handle(path.Join(p, "/splash"), http.HandlerFunc(s.splash)) // Prometheus
@@ -157,6 +165,7 @@ func (s *Server) dispatch(w http.ResponseWriter, r *http.Request) {
 		s.logger.For(ctx).Error("error parsing request body", zap.Error(err))
 		return
 	}
+	requestedAt := time.Now().UTC()
 
 	// get request context
 	reqContext := &notifications.RequestContext{
@@ -190,8 +199,20 @@ func (s *Server) dispatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = s.rideHistory.Store(ctx, &RideHistoryEntry{
+		RequestID:       dispatchReq.RequestID,
+		PickupLocation:  pickupLoc.Name,
+		DropoffLocation: dropoffLoc.Name,
+		RequestedAt:     requestedAt,
+		DriverPlate:     "Pending",
+	})
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("couldn't persist ride history", zap.Error(err))
+		return
+	}
+
 	// dispatch a driver request
-	err = s.dispatcher.DispatchDriver(ctx, &dispatchReq, pickupLoc, dropoffLoc)
+	err = s.dispatcher.DispatchDriver(ctx, &dispatchReq, pickupLoc, dropoffLoc, requestedAt)
 	if httperr.HandleError(w, err, http.StatusInternalServerError) {
 		s.logger.For(ctx).Error("couldn't trigger dispatch request", zap.Error(err))
 		return
@@ -234,8 +255,38 @@ func (s *Server) notifications(w http.ResponseWriter, r *http.Request) {
 		s.logger.For(ctx).Error("request failed", zap.Error(err))
 		return
 	}
+	for _, notification := range data.Notifications {
+		requestID, driverPlate, ok := extractDispatchedDriver(notification.ID, notification.Body)
+		if !ok {
+			continue
+		}
+		if err := s.rideHistory.UpdateDriverPlate(ctx, requestID, driverPlate); err != nil {
+			s.logger.For(ctx).Error("failed to update driver plate in ride history", zap.Error(err))
+		}
+	}
 
 	s.writeResponse(data, w, r)
+}
+
+func (s *Server) rideHistoryList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	s.logger.For(ctx).Info("HTTP request received", zap.String("method", r.Method), zap.Stringer("url", r.URL))
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rides, err := s.rideHistory.List(ctx)
+	if httperr.HandleError(w, err, http.StatusInternalServerError) {
+		s.logger.For(ctx).Error("request failed", zap.Error(err))
+		return
+	}
+
+	resp := RideHistoryResponse{
+		Total: len(rides),
+		Rides: rides,
+	}
+	s.writeResponse(resp, w, r)
 }
 
 func (s *Server) writeResponse(response interface{}, w http.ResponseWriter, r *http.Request) {
@@ -247,4 +298,23 @@ func (s *Server) writeResponse(response interface{}, w http.ResponseWriter, r *h
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+func extractDispatchedDriver(notificationID, notificationBody string) (uint, string, bool) {
+	idMatches := dispatchedDriverIDRegex.FindStringSubmatch(notificationID)
+	if len(idMatches) != 2 {
+		return 0, "", false
+	}
+
+	requestID, err := strconv.Atoi(idMatches[1])
+	if err != nil {
+		return 0, "", false
+	}
+
+	bodyMatches := dispatchedDriverBodyRegex.FindStringSubmatch(notificationBody)
+	if len(bodyMatches) != 2 {
+		return uint(requestID), "", false
+	}
+
+	return uint(requestID), bodyMatches[1], true
 }

--- a/services/frontend/server_history_test.go
+++ b/services/frontend/server_history_test.go
@@ -1,0 +1,47 @@
+package frontend
+
+import (
+	"testing"
+)
+
+func TestExtractDispatchedDriver(t *testing.T) {
+	t.Parallel()
+
+	requestID, driverPlate, ok := extractDispatchedDriver(
+		"req-42-dispatched-driver",
+		"Driver A-123 arriving in 2m3s",
+	)
+	if !ok {
+		t.Fatalf("expected dispatched-driver notification to match")
+	}
+	if requestID != 42 {
+		t.Fatalf("unexpected request id: got %d want 42", requestID)
+	}
+	if driverPlate != "A-123" {
+		t.Fatalf("unexpected driver plate: got %q want %q", driverPlate, "A-123")
+	}
+}
+
+func TestExtractDispatchedDriverInvalidID(t *testing.T) {
+	t.Parallel()
+
+	_, _, ok := extractDispatchedDriver(
+		"req-abc-dispatched-driver",
+		"Driver A-123 arriving in 2m3s",
+	)
+	if ok {
+		t.Fatalf("expected invalid notification ID to fail parsing")
+	}
+}
+
+func TestExtractDispatchedDriverInvalidBody(t *testing.T) {
+	t.Parallel()
+
+	_, _, ok := extractDispatchedDriver(
+		"req-42-dispatched-driver",
+		"Finding an available driver",
+	)
+	if ok {
+		t.Fatalf("expected non-dispatch body to fail parsing")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add persistent `ride_history` storage in MySQL and write records during dispatch flow
- expose `GET /ride-history` from frontend with `{ total, rides[] }`
- render a Ride History list view in the React home page with total ride count and entry details (pickup, dropoff, request time, driver plate)
- add parser/unit tests for dispatched-driver notification extraction used by history updates

## Validation
- `go test ./...`
- `go vet ./...`
- `yarn lint` (known pre-existing warnings in repo; no new lint errors)
- `make build-frontend-app`
- `signadot smart-test run --cluster "$CLUSTER_NAME" -d "/workspace/smart-tests" --timeout 5m` (2/2 checks passed)
- manual E2E on local frontend against proxied `hotrod-devmesh` services: dispatch request + notifications + `GET /ride-history` verified new persisted row including pickup/dropoff/requestedAt/driverPlate

## Walkthrough artifacts
[ride_history_feature_demo.mp4](https://cursor.com/agents/bc-67b10b21-474e-4a0e-95ce-234f2a6329b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_feature_demo.mp4)
[Ride history initial state](https://cursor.com/agents/bc-67b10b21-474e-4a0e-95ce-234f2a6329b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_initial_state.webp)
[Ride request success toast](https://cursor.com/agents/bc-67b10b21-474e-4a0e-95ce-234f2a6329b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_request_toast.webp)
[Ride history updated state](https://cursor.com/agents/bc-67b10b21-474e-4a0e-95ce-234f2a6329b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_history_final_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67b10b21-474e-4a0e-95ce-234f2a6329b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67b10b21-474e-4a0e-95ce-234f2a6329b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

