### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+HotROD (Rides on Demand) is a microservices ride-hailing demo written in Go with a React (Vite/TypeScript) frontend. A single Go binary (`cmd/hotrod`) runs 4 services: **frontend** (:8080), **location** (:8081), **driver** (:8082 healthz), **route** (:8083 gRPC). Infrastructure deps: Redis, MySQL (MariaDB), Kafka.
+
+### Infrastructure (Docker)
+
+Three Docker containers provide infrastructure. Docker is pre-installed; the nested-VM workarounds (fuse-overlayfs, iptables-legacy) are already configured. Start/restart containers:
+
+```bash
+sudo dockerd &>/tmp/dockerd.log &
+sleep 3
+sudo docker start redis mariadb kafka
+```
+
+If containers don't exist yet (first-time setup):
+
+```bash
+sudo docker run -d --name redis -p 6379:6379 redis:7.2.3
+sudo docker run -d --name mariadb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=abc -e MYSQL_DATABASE=location -e MYSQL_ROOT_HOST=% mariadb:11.6
+sudo docker run -d --name kafka -p 9092:9092 -p 29093:29093 confluentinc/confluent-local:7.5.0
+```
+
+### Running all services locally
+
+Default env vars point to k8s DNS names. Override them for localhost. See `k8s/base/*.yaml` for the full env var list per service. Key overrides:
+
+| Variable | Local value |
+|---|---|
+| `REDIS_ADDR` | `localhost:6379` |
+| `MYSQL_ADDR` | `localhost:3306` |
+| `MYSQL_PASS` | `abc` |
+| `KAFKA_BROKER_ADDR` | `localhost:9092` |
+| `LOCATION_ADDR` | `localhost:8081` |
+| `ROUTE_ADDR` | `localhost:8083` |
+
+Additionally, the driver service **requires** three baseline env vars or it panics on startup. Use these dummy values for local dev:
+
+| Variable | Local value |
+|---|---|
+| `*_BASELINE_KIND` | `Deployment` |
+| `*_BASELINE_NAMESPACE` | `hotrod` |
+| `*_BASELINE_NAME` | `driver` |
+
+(The `*` prefix matches the vendor-specific env prefix used in `pkg/config/` and `k8s/base/driver.yaml`.)
+
+Run all services: `go run ./cmd/hotrod all` with the above env vars exported.
+
+**Non-obvious gotchas:**
+- The three baseline env vars above are **required** or the driver service panics. See `services/driver/consumer.go` line 40.
+- The vendor routeserver is unavailable locally; the driver's routing watcher retries in the background — this is harmless.
+- OTEL trace export errors to `:4318` are harmless (no local Jaeger). Set `OTEL_EXPORTER_TYPE=stdout` to log traces to stdout instead, or ignore the errors.
+- The React frontend must be built before running the Go binary: `make build-frontend-app` (uses `yarn && yarn build`). The built assets are Go-embedded via `//go:embed`.
+
+### Lint / Test / Build
+
+- **Go tests:** `go test ./...`
+- **Go build:** `make build` (builds frontend first, then Go binary to `dist/`)
+- **Frontend lint:** `cd services/frontend/react_app && yarn lint` (has pre-existing warnings/errors)
+- **Frontend dev server:** `cd services/frontend/react_app && yarn dev` (Vite dev server on :5173, for React-only development)
+- **Hot-reload:** `air` (requires [air](https://github.com/air-verse/air) installed; uses `.air.toml` config)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with comprehensive Cursor Cloud development instructions for the HotROD microservices demo application.

### What's included

- Docker infrastructure setup (Redis, MariaDB, Kafka containers)
- Environment variable overrides for local development
- Non-obvious gotcha: driver service panics without baseline env vars
- Lint, test, build, and run commands reference

### Development Environment Verification

All services were verified running locally:

| Check | Status |
|---|---|
| `go test ./...` | All pass |
| `make build` | Success |
| `yarn lint` (React frontend) | Pre-existing warnings |
| Frontend HTTP (:8080) | Serving React SPA |
| Location service (:8081) | Returning locations from MySQL |
| Driver service (:8082) | Kafka consumer running |
| Route service (:8083) | gRPC server listening |
| Ride dispatch flow | Working end-to-end |

### Demo

[hotrod_ride_dispatch_demo.mp4](https://cursor.com/agents/bc-410755be-64f8-4dbd-b8ca-e5a0ffccf303/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhotrod_ride_dispatch_demo.mp4)

Dispatching a ride from "Rachel's Floral Designs" to "Trom Chocolatier" via the HotROD UI.

[HotROD main UI](https://cursor.com/agents/bc-410755be-64f8-4dbd-b8ca-e5a0ffccf303/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhotrod_main_ui.webp)
[Ride dispatched successfully](https://cursor.com/agents/bc-410755be-64f8-4dbd-b8ca-e5a0ffccf303/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fride_dispatched.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-410755be-64f8-4dbd-b8ca-e5a0ffccf303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-410755be-64f8-4dbd-b8ca-e5a0ffccf303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

