### PR TITLE
ci: pin GitHub Actions to SHAs (ENG-921)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       # The paths-filter action requires a checkout step for push events.
       - if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -52,17 +52,17 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Go Mod Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-${{ hashFiles('**/go.sum') }}
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-
 
       - name: Go Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-build-${{ hashFiles('**/go.sum') }}
@@ -78,10 +78,10 @@ jobs:
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-build-
 
       - name: Setup qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Docker Login
-        uses: docker/login-action@v1.9.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -103,10 +103,10 @@ jobs:
       SANDBOX_IMAGE_TAG: ${{ github.sha }}-linux-amd64
       SANDBOX_NAME: pr-${{ github.event.number }}-route
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -182,10 +182,10 @@ jobs:
       SANDBOX_IMAGE_TAG: ${{ github.sha }}-linux-amd64
       SANDBOX_NAME: pr-${{ github.event.number }}-frontend
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -235,10 +235,10 @@ jobs:
       SANDBOX_IMAGE_TAG: ${{ github.sha }}-linux-amd64
       SANDBOX_NAME: pr-${{ github.event.number }}-location
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -289,10 +289,10 @@ jobs:
       SANDBOX_IMAGE_TAG: ${{ github.sha }}-linux-amd64
       SANDBOX_NAME: pr-${{ github.event.number }}-driver
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
## Summary

Pin every external GitHub Action in `build.yml` to a full commit SHA, keeping the major tag as a trailing comment. Add a `github-actions` Dependabot config so the SHAs and tag comments stay up to date.

Mutable tags like `@v2` can be repointed by a compromised maintainer or stolen token; pinning to a 40-char SHA makes the reference immutable.

While in here, deprecated `@v1`/`@v2` refs (which run on EOL Node runtimes) were bumped to the current stable major. No workflow behavior changes are intended.

### Pinned actions

- `actions/checkout` v2/v3 -> v4 `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/setup-go` v2 -> v5 `40f1582b2485089dde7abd97c1529aa768e1baff`
- `actions/cache` v4 `0057852bfaa89a56745cba8c7296529d2fc39830`
- `docker/setup-qemu-action` v1 -> v3 `c7c53464625b32c7a7e944ae62b3e17d2b600130`
- `docker/login-action` v1.9.0 -> v3 `c94ce9fb468520275223c153574b00df6fe4bcc9`
- `dorny/paths-filter` v2 -> v3 `d1c1ffe0248fe513906c8e24db8ea791d46f8590`

## Test plan

- [ ] CI runs cleanly on this PR (build + sandbox-* jobs path-filtered as before)
- [ ] Dependabot picks up the new `github-actions` ecosystem and opens upgrade PRs going forward

Refs https://linear.app/signadot/issue/ENG-921
