### PR TITLE
Add sd-driver prefix to driver plates

### DIFF
--- a/playwright-tests/basic.spec.ts
+++ b/playwright-tests/basic.spec.ts
@@ -24,6 +24,6 @@ test.describe("Request a ride", () => {
 
 		await expect(
 			page.locator("//div[p[2][contains(text(), 'driver')]]/p[4]").last(),
-		).toHaveText(/.*T7\d{5}C.*/);
+		).toHaveText(/.*sd-driver-T7\d{5}C.*/);
 	});
 });

--- a/services/driver/driverstore.go
+++ b/services/driver/driverstore.go
@@ -38,6 +38,13 @@ type driverStore struct {
 	logger log.Factory
 }
 
+const driverPlatePrefix = "sd-driver"
+
+func formatDriverID(driverNumber int) string {
+	return fmt.Sprintf("%s%s-T7%05dC%s",
+		config.GetDriverIDPrefix(), driverPlatePrefix, driverNumber, config.GetDriverIDSuffix())
+}
+
 func newDriverStore(tracer trace.Tracer, logger log.Factory) *driverStore {
 	return &driverStore{
 		tracer: tracer,
@@ -59,8 +66,7 @@ func (s *driverStore) FindDriverIDs(ctx context.Context) []string {
 	drivers := make([]string, 10)
 	for i := range drivers {
 		// #nosec
-		drivers[i] = fmt.Sprintf("%sT7%05dC%s",
-			config.GetDriverIDPrefix(), rand.Int()%100000, config.GetDriverIDSuffix())
+		drivers[i] = formatDriverID(rand.Int() % 100000)
 	}
 	s.logger.For(ctx).Info("Found drivers", zap.Strings("drivers", drivers))
 	return drivers

--- a/services/driver/driverstore_test.go
+++ b/services/driver/driverstore_test.go
@@ -1,0 +1,16 @@
+package driver
+
+import (
+	"testing"
+)
+
+func TestFormatDriverIDAddsDriverPlatePrefix(t *testing.T) {
+	t.Setenv("DRIVER_ID_PREFIX", "test-")
+	t.Setenv("DRIVER_ID_SUFFIX", "-tail")
+
+	got := formatDriverID(42)
+	want := "test-sd-driver-T700042C-tail"
+	if got != want {
+		t.Fatalf("formatDriverID() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prefix generated driver plate IDs with `sd-driver`
- Add a focused unit test for driver ID formatting
- Update the Playwright ride-flow assertion to expect the new plate prefix

## Validation
- `go test ./services/driver`
- `go test ./...`
- GitHub PR checks passed, including `sandbox-driver` and `Sandbox: pr-301-driver`
- Ran requested tagged Signadot plan: `frontend-request-ride` against `pr-301-driver` (execution `45zbu2un9ng06`). The plan reached the frontend but failed on its existing toast locator because `Ride requested to Rachel's Floral Designs` matched two identical toast elements before any driver plate assertion.
- Ran a one-off Signadot Playwright plan against `pr-301-driver` (plan `vp54cjr9407u6`, execution `pyfyzx2w3hs9d`) asserting `/Driver sd-driver-T7\d{5}C arriving in .+/`; result: `1 passed`, phase `completed`.

## Walkthrough artifacts
[Signadot validation screenshot showing sd-driver plate](https://cursor.com/agents/bc-12d93021-5ef6-4caa-9c99-5d766eb56873/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsd_driver_plate_signadot.png)

[sd_driver_plate_signadot.webm](https://cursor.com/agents/bc-12d93021-5ef6-4caa-9c99-5d766eb56873/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsd_driver_plate_signadot.webm)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1019](https://linear.app/signadot/issue/ENG-1019/add-prefix-sd-driver-to-plate-returned-by-driver-microservice)

<div><a href="https://cursor.com/agents/bc-12d93021-5ef6-4caa-9c99-5d766eb56873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12d93021-5ef6-4caa-9c99-5d766eb56873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

