### PR TITLE
k8s: add istio ambient overlays for e2e (VirtualService + gateway-api)

### DIFF
--- a/k8s/overlays/prod/istio-ambient-gatewayapi/kustomization.yaml
+++ b/k8s/overlays/prod/istio-ambient-gatewayapi/kustomization.yaml
@@ -1,0 +1,11 @@
+# Ambient (Gateway API routing). No sidecar injection — pods are captured by
+# ztunnel via the namespace's istio.io/dataplane-mode=ambient label (set by the
+# e2e app-config install), and L7 header-based sandbox routing goes through a
+# waypoint (namespace istio.io/use-waypoint=waypoint) with the HTTPRoute/GRPCRoute
+# from get-gatewayapi-routes attached to the Services.
+resources:
+- ../../../base
+- waypoint.yaml
+
+components:
+  - ../../../components/get-gatewayapi-routes

--- a/k8s/overlays/prod/istio-ambient-gatewayapi/waypoint.yaml
+++ b/k8s/overlays/prod/istio-ambient-gatewayapi/waypoint.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE

--- a/k8s/overlays/prod/istio-ambient/kustomization.yaml
+++ b/k8s/overlays/prod/istio-ambient/kustomization.yaml
@@ -1,0 +1,9 @@
+# Ambient (VirtualService routing). No sidecar injection — pods are captured by
+# ztunnel via the namespace's istio.io/dataplane-mode=ambient label (set by the
+# e2e app-config install), and L7 header-based sandbox routing goes through a
+# waypoint (namespace istio.io/use-waypoint=waypoint) enforcing the operator's
+# generated VirtualServices. virtual-service.yaml holds the baseline app routes.
+resources:
+- ../../../base
+- virtual-service.yaml
+- waypoint.yaml

--- a/k8s/overlays/prod/istio-ambient/virtual-service.yaml
+++ b/k8s/overlays/prod/istio-ambient/virtual-service.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: frontend
+spec:
+  hosts:
+  - frontend
+  http:
+  - route:
+    - destination:
+        host: frontend
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: location
+spec:
+  hosts:
+  - location
+  http:
+  - route:
+    - destination:
+        host: location
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: route
+spec:
+  hosts:
+  - route
+  http:
+  - route:
+    - destination:
+        host: route

--- a/k8s/overlays/prod/istio-ambient/waypoint.yaml
+++ b/k8s/overlays/prod/istio-ambient/waypoint.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE


### PR DESCRIPTION
## What

Add ambient-mode overlays under `k8s/overlays/prod/` so the signadot e2e suite can exercise hotrod on **Istio ambient**:

- **`istio-ambient`** — ambient dataplane + waypoint, VirtualService routing.
- **`istio-ambient-gatewayapi`** — ambient dataplane + waypoint, gateway-api (HTTPRoute/GRPCRoute) routing.

No sidecar injection (unlike the `istio` overlay). The e2e app-config enrolls the namespace (`istio.io/dataplane-mode=ambient` + `use-waypoint`); each overlay adds the waypoint `Gateway` and reuses the existing baseline routes (`virtual-service.yaml` / `get-gatewayapi-routes`). Both render clean with zero `sidecar.istio.io/inject` labels.

Mirrors the e2e-multi ambient overlays added in `signadot/signadot` (PR #7108), which are validated on k3sctl ambient clusters (the operator routes sandboxes through the waypoint for both VS and gateway-api).

## Follow-up

Cut a new hotrod e2e tag (`e2e-v2.12`) from `main` — which includes these overlays **and** #287 (GRPCRoute fix for linkerd-gatewayapi) — then bump `REPO_TAG` in `sandboxes/tests/e2e/data/apps/hotrod/*/app-config.yaml` (currently `e2e-v2.11`). That enables hotrod ambient e2e and closes the linkerd-gatewayapi gRPC-preview failure in one move.

Resolves ENG-1066.